### PR TITLE
pom.xml: set the jdk.min.version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <license.owner>SonarSource</license.owner>
     <license.years>2008</license.years>
     <license.mailto>sonarqube@googlegroups.com</license.mailto>
-    <jdk.min.version>11</jdk.min.version>
+    <jdk.min.version>8</jdk.min.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Fixing the following error for older projects:

CloverPlugin has been compiled by a more recent version of the Java Runtime

[ERROR] Failed to execute goal
 org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.0.2155:sonar
 (default-cli) on project integration:

 The plugin [sonarclover] does not support Java 1.8.0_292:
  org/sonar/plugins/clover/CloverPlugin has been compiled by a more
  recent version of the Java Runtime (class file version 55.0),
  this version of the Java Runtime only recognizes class file
  versions up to 52.0 -> [Help 1]




SonarQube <9 still supports java 1.8, I tried to use this plugin with an old project and it didn't work. Changing the jdk.min.version to 8 solved my problem.