### PR TITLE
NoClassDefFoundError after upgrading to SonarQube 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,4 @@ ARG VERSION=latest
 FROM sonarqube:${VERSION}
 
 COPY target/sonar-clover-plugin.jar /opt/sonarqube/extensions/plugins/
+ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.8/sonar-groovy-plugin-1.8.jar /opt/sonarqube/extensions/plugins/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,3 @@ ARG VERSION=latest
 FROM sonarqube:${VERSION}
 
 COPY target/sonar-clover-plugin.jar /opt/sonarqube/extensions/plugins/
-ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.8/sonar-groovy-plugin-1.8.jar /opt/sonarqube/extensions/plugins/

--- a/its/plugin/src/test/java/com/sonar/clover/it/CloverTest.java
+++ b/its/plugin/src/test/java/com/sonar/clover/it/CloverTest.java
@@ -37,7 +37,7 @@ public class CloverTest {
 
   @ClassRule
   public static Orchestrator orchestrator = Orchestrator.builderEnv()
-    .setSonarVersion("6.7.5")
+    .setSonarVersion("9.1.0")
     .setOrchestratorProperty("javaVersion", "LATEST_RELEASE")
     .addPlugin("java")
     .setOrchestratorProperty("groovyVersion", "LATEST_RELEASE")

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.github.sfeir-open-source</groupId>
   <artifactId>sonar-clover-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>4.2-SNAPSHOT</version>
+  <version>5.0-SNAPSHOT</version>
 
   <name>Sonar Clover Plugin</name>
   <description>Get code coverage with http://openclover.org/</description>
@@ -43,7 +43,7 @@
   </distributionManagement>
 
   <properties>
-    <sonar.version>6.7</sonar.version>
+    <sonar.version>9.1.0.47736</sonar.version>
     <sonar.pluginName>Clover</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.clover.CloverPlugin</sonar.pluginClass>
     <sonar.pluginUrl>${project.scm.url}</sonar.pluginUrl>
@@ -57,6 +57,13 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
+      <version>${sonar.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonarsource.sonarqube</groupId>
+      <artifactId>sonar-plugin-api-impl</artifactId>
       <version>${sonar.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -85,7 +92,31 @@
       <version>3.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>woodstox-core-lgpl</artifactId>
+      <version>4.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.staxmate</groupId>
+      <artifactId>staxmate</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+
     <!-- unit tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.8.1</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
@@ -102,6 +133,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/org/sonar/plugins/clover/CloverPluginTest.java
+++ b/src/test/java/org/sonar/plugins/clover/CloverPluginTest.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.clover;
 
 import org.junit.Test;
 import org.sonar.api.Plugin;
+import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
@@ -33,8 +34,8 @@ public class CloverPluginTest {
   public void test_define() {
     final Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(
             Version.parse("9.1.0"),
-            null,
-            null));
+            SonarQubeSide.SCANNER,
+            SonarEdition.COMMUNITY));
     new CloverPlugin().define(context);
     assertThat(context.getExtensions()).hasSize(1);
   }

--- a/src/test/java/org/sonar/plugins/clover/CloverPluginTest.java
+++ b/src/test/java/org/sonar/plugins/clover/CloverPluginTest.java
@@ -32,8 +32,9 @@ public class CloverPluginTest {
   @Test
   public void test_define() {
     final Plugin.Context context = new Plugin.Context(SonarRuntimeImpl.forSonarQube(
-            Version.parse("6.7.4"),
-            SonarQubeSide.SCANNER));
+            Version.parse("9.1.0"),
+            null,
+            null));
     new CloverPlugin().define(context);
     assertThat(context.getExtensions()).hasSize(1);
   }


### PR DESCRIPTION
sonar-plugin-api no longer provides the necessary XML libraries, resulting in
java.lang.NoClassDefFoundError: com/ctc/wstx/stax/WstxInputFactory

We have this code running in production, and so far no complaints.

As you will see, this PR also adresses the issue regarding the groovy grvy language code. It was simply a matter of activating the sonar-groovy plugin in the test sonarqube.
